### PR TITLE
Add logic to download and save orders

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+    "env": {
+      "node": true,
+      "es2021": true
+    },
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "ecmaVersion": 12,
+      "sourceType": "module"
+    },
+    "plugins": ["@typescript-eslint"],
+    "rules": {
+      "no-console": "warn"
+    }
+  }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# npm
+database.sqlite
+node_modules
+package-lock.json
+npm-shrinkwrap.json
+*.log
+*.gz
+
+# Coveralls
+.nyc_output
+coverage
+
+# Benchmarking
+benchmarks/graphs

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all"
+  }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "express-middleware-challenge",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "dev": "nodemon src/index.ts",
+    "lint": "eslint src/**/*.{ts,tsx}",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "axios": "^1.7.7",
+    "better-sqlite3": "^11.5.0",
+    "express": "^4.21.1",
+    "sequelize": "^6.37.5",
+    "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.9.0",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "eslint": "^9.15.0",
+    "nodemon": "^3.1.7",
+    "prettier": "^3.3.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import sequelize from './utils/database';
+import { router as ordersRoute } from './routes/orders';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/orders', ordersRoute);
+
+// Sync database (creates table if it doesn't exist)
+sequelize.sync().then(() => {
+    console.log('Database synced!');
+    app.listen(3000, () => {
+      console.log('Server is running on port 3000');
+    });
+});

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -1,0 +1,39 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../utils/database';
+
+class Order extends Model {
+  public id!: number;
+  public item!: string;
+  public customer!: string;
+  public billingFrequency!: 'daily' | 'weekly' | 'monthly';
+}
+
+Order.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    item: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    customer: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    billingFrequency: {
+      type: DataTypes.ENUM('daily', 'weekly', 'monthly'),
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'Order',
+    tableName: 'orders',
+    timestamps: false,
+  }
+);
+
+export default Order;

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import Order from '../models/Order';
+import { fetchOrders } from '../services/ordersService';
+
+const router = Router();
+
+router.get('/download', async (req, res) => {
+    try {
+      // Fetch orders from Service A
+      const orders = await fetchOrders();
+  
+      res.status(200).json({ message: 'Orders fetched and saved', orders });
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ error: 'An error occurred while fetching orders' });
+    }
+});
+
+// Route to view saved orders
+router.get('/retrieve', async (req, res) => {
+  try {
+    const orders = await Order.findAll(); // Find all orders in the database
+    res.status(200).json(orders);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'An error occurred while fetching orders from the database' });
+  }
+});
+
+export { router };

--- a/src/services/ordersService.ts
+++ b/src/services/ordersService.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import Order from '../models/Order'; // Import the Sequelize Order model
+
+const SERVICE_A_URL = 'https://ie24.challenge.dev.kanpla.io/api/service-a';
+
+// Fetch and save orders, iterating through all pages
+export const fetchOrders = async () => {
+  try {
+    let page = 1;
+    const limit = 10;
+    let hasMoreOrders = true;
+    const allOrders: any[] = [];
+
+    while (hasMoreOrders) {
+      const response = await axios.get(SERVICE_A_URL, { params: { page, limit } });
+      const { orders } = response.data;
+
+      if (Array.isArray(orders) && orders.length > 0) {
+        allOrders.push(...orders);
+        await saveOrdersToDatabase(orders); // Save current page's orders to the database
+        page += 1;
+      } else {
+        hasMoreOrders = false; // Stop fetching if no orders are returned
+      }
+    }
+
+    return allOrders;
+  } catch (error) {
+    console.error('Error fetching orders:', error);
+    throw new Error('Failed to fetch orders');
+  }
+};
+
+const saveOrdersToDatabase = async (orders: any[]) => {
+    for (const order of orders) {
+      await Order.upsert({
+        id: order.id,
+        item: order.item,
+        customer: order.customer,
+        billingFrequency: order.billingFrequency,
+      });
+    }
+  };
+
+export const getOrdersFromDatabase = async () => {
+  try {
+    const orders = await Order.findAll(); // Sequelize method to fetch all orders
+    return orders;
+  } catch (error) {
+    console.error('Error fetching orders from the database:', error);
+    throw new Error('Failed to fetch orders from database');
+  }
+};

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,0 +1,9 @@
+import { Sequelize } from 'sequelize';
+
+// Initialize Sequelize (use SQLite in this case)
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: './database.sqlite', // SQLite file location
+});
+
+export default sequelize;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+      "target": "ES6",
+      "module": "commonjs",
+      "outDir": "./dist",
+      "rootDir": "./src",
+      "strict": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules"]
+  }


### PR DESCRIPTION
Download and upsert orders  from the api for each page.

Sequalize model to save the orders in a local sqllite db. 

Endpoints to download and to read the orders that have been saved. 

Also a couple of config files since this is the first commit. 